### PR TITLE
added right angle JST PH connecter

### DIFF
--- a/microbuilder.scad
+++ b/microbuilder.scad
@@ -19,3 +19,43 @@ module microbuilder_LQFP100(name, value) {
 module microbuilder_QFN24_4MM(name, value) {
 	qfn(24, name=name, value=value);
 }
+
+/*copied from con-JST-PH.scad and rotated, changed color, other small changes
+ * ...probably would have been cleaner to make a new housing and rotate pins
+ * actual part is more complicated, did not include various cut-ins and hole in top of receiver
+ */
+module microbuilder_JSTPH(p=2) {
+    translate([0,-2.45,(2.25 - 1.7 + 5.65/2)]){ 
+        rotate([-90,0,0]){ 
+            color(silver) render() for (i = [0:p - 1]) {
+                //inside pins
+                translate([(i - ((p - 1) * 0.5)) * 2, 0, -0.5]) rotate(45) hull() {
+                    cylinder(d=0.5 / cos(180/4), h=5, $fn=4);
+                    cylinder(d=0.25, h=5.5, $fn=4);
+                }
+                //vertical pins
+                translate([(i - ((p - 1) * 0.5)) * 2, 3.35, -0.25]) rotate([90,45,0]) cylinder(d=0.5 / cos(180/4), h=3.56, $fn=4);
+                //board pins
+                translate([(i - ((p - 1) * 0.5)) * 2, 3.1, -2.85]) rotate(45) hull() {
+                    cylinder(d=0.5 / cos(180/4), h=2.35, $fn=4);
+                    translate([0, 0, -0.25]) cylinder(d=0.25 / cos(180/4), h=ee, $fn=4);
+                }
+            } //end pins color
+            
+            color( c = [.15,.15,.15, 1]) render() difference() {
+                union(){
+                    translate([0, 2.25 - 1.7, 0  ]) cc([3 + (p-1) * 2 + 3, 5.65, 6]);
+                    translate([(3 + (p-1) * 2 + 3)/2-0.8/2, 2.25 - 1.7 + 1.85/2, -1.8  ]) cc([0.8, 3.8, 1.8]);
+                    translate([-((3 + (p-1) * 2 + 3)/2-0.8/2), 2.25 - 1.7 + 1.85/2, -1.8  ]) cc([0.8, 3.8, 1.8]);
+                }
+                translate([0, 2.25 - 1.7 + 0.15, 0.4]) cc([p * 2 + 1.5, 3.6, 6]);
+                translate([0, 0         , 0.4]) cc([p * 2 - 2  , 4.1, 6]);
+            }
+            
+        }
+    }
+}
+
+module microbuilder_JSTPH2(name, value) {
+	microbuilder_JSTPH(2);
+}


### PR DESCRIPTION
Not the most elegant, some excessive math, but it works for https://github.com/adafruit/Adafruit-Feather-32u4-Basic-Proto-PCB

Module added to microbuilder file, it works for arbitrary number of pins, defaults to 2 as in con-JST-PH.scad (which was source for starting point)

Outer dimensions are correct, except for the angle on the rear 'fins' that are parallel to the exposed pins. Did not model all cut-ins and such things but the outcome as of now should be good for differencing purposes

Let me know if you are thinking of different organization, naming, model conventions!

![image](https://user-images.githubusercontent.com/10883713/99887380-abd9e600-2bf8-11eb-9726-d1f2ca507d19.png)
![image](https://user-images.githubusercontent.com/10883713/99887387-bb592f00-2bf8-11eb-91ee-f0fefff4dff3.png)
